### PR TITLE
Security improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ var githubAuth = require('github-auth');
 var config = {
 	team: 'some-team',
 	organization: 'my-company',
-	autologin: true // This automatically redirects you to github to login.
+	autologin: true, // This automatically redirects you to github to login.
+	hideAuthInternals: true // After authentication this redirects to original url but without query parameters 'code' and 'state'.
 };
 var gh = githubAuth('github app id', 'github app secret', config);
 app.use(gh.authenticate);
@@ -80,7 +81,7 @@ http.createServer(function(request, response) {
 		organization: 'my-company'
 	};
 	githubAuth('github app id', 'github app secret', config).authenticate(request, response, function(err) {
-		if(!err) return response.end(err);
+		if (err) return response.end(err);
 
 		// your http code here
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-auth",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi, I made some security improvements:
1. use query parameter `state` as per docs: https://developer.github.com/v3/oauth/#parameters
2. we had an issue with autologin, when users after being redirected back from github had a url like "https://myservice/?code=12345678" and shared this authenticated link with other people thus unknowingly breaking security, because using this link other people didn't have to authenticate via github, so I added `hideAuthInternals` config option that after successful authentication will redirect back but without query params `code` and `state`