### PR TITLE
Fix case sensitive teams/orgs

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = function (clientId, clientSecret, config) {
 			}
 
 			var teamId = teams.filter(function (x) {
-				return x.name === config.team;
+				return x.name.toLowerCase() === config.team;
 			})[0].id;
 			cb(null, teamId);
 		});
@@ -167,7 +167,7 @@ module.exports = function (clientId, clientSecret, config) {
 
 			if (!Array.isArray(json)) return callback(null, false);
 			var orgLogins = json.map(function (obj) {
-				return obj.login;
+				return obj.login.toLowerCase();
 			});
 			var authorized = orgLogins.indexOf(config.organization) !== -1;
 


### PR DESCRIPTION
These additional toLowerCase() were needed to make mixed case orgs/teams work